### PR TITLE
Minor changes for temperature and generic sensor

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -239,6 +239,12 @@ module.exports = {
           value itself."
         type: "string"
         default: "$value"
+      isFahrenheit:
+        description: "
+          boolean that sets the right units if the temperature is to be reported in
+           Fahrenheit"
+        type: "boolean"
+        default: false
     required: ["protocols"]
   }
   HomeduinoRFWeatherStation: {
@@ -300,7 +306,7 @@ module.exports = {
               type: "integer"
             decimals:
               description: "Decimals of the value in the rf message"
-              type: "integer"
+              type: "number"
               default: 0
             baseValue:
               description: "Offset that will be added to the value in the rf message"

--- a/homeduino.coffee
+++ b/homeduino.coffee
@@ -637,9 +637,8 @@ module.exports = (env) ->
       @attributes = {}
 
       if hasTemperature
-        tempUnit = '°C'
-        if isFahrenheit
-          tempUnit = '°F'
+        if isFahrenheit then tempUnit = '°F'
+        else tempUnit = '°C'
         @attributes.temperature = {
           description: "the messured temperature"
           type: "number"

--- a/homeduino.coffee
+++ b/homeduino.coffee
@@ -623,7 +623,7 @@ module.exports = (env) ->
       hasHumidity = false
       hasLowBattery = false # boolean battery indicator
       hasBattery = false # numeric battery indicator
-      isFahrenheit = config.fahrenheit
+      isFahrenheit = config.isFahrenheit
       for p in config.protocols
         _protocol = Board.getRfProtocol(p.name)
         unless _protocol?
@@ -637,14 +637,16 @@ module.exports = (env) ->
       @attributes = {}
 
       if hasTemperature
+        tempUnit = '°C'
+        if isFahrenheit
+          tempUnit = '°F'
         @attributes.temperature = {
           description: "the messured temperature"
           type: "number"
-          unit: '°C'
-          if isFahrenheit
-            unit: '°F'
+          unit: tempUnit
           acronym: 'T'
         }
+
       if hasHumidity
         @attributes.humidity = {
           description: "the messured humidity"

--- a/homeduino.coffee
+++ b/homeduino.coffee
@@ -623,6 +623,7 @@ module.exports = (env) ->
       hasHumidity = false
       hasLowBattery = false # boolean battery indicator
       hasBattery = false # numeric battery indicator
+      isFahrenheit = config.fahrenheit
       for p in config.protocols
         _protocol = Board.getRfProtocol(p.name)
         unless _protocol?
@@ -640,6 +641,8 @@ module.exports = (env) ->
           description: "the messured temperature"
           type: "number"
           unit: '°C'
+          if isFahrenheit
+            unit: '°F'
           acronym: 'T'
         }
       if hasHumidity


### PR DESCRIPTION
Allow number values for decimals in generic sensor, instead of only ints. This allows arbitrary ranges for  mapping the value into, rather than the older presets of 10x.

Allows for specifying if the temperature being reported is in fahrenheit or not, and sets the units accordingly. Does not change the actual value as that can be controlled by the processingTemp field. This ensures that the control for whether the incoming value is in C or F is something the user can control.