### PR TITLE
Added config option to invert signal that is send for shutters

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -226,6 +226,10 @@ module.exports = {
         type: "boolean"
         description: "Resend signal even if switch has the requested state already"
         default: true
+      inverted:
+        description: "Sending inverted values when pressing up or down"
+        type: "boolean"
+        default: false
   }
   HomeduinoRFTemperature: {
     title: "HomeduinoRFTemperature config options"

--- a/homeduino.coffee
+++ b/homeduino.coffee
@@ -690,9 +690,11 @@ module.exports = (env) ->
         if @_types[p.name] is "command"
           p.options.command = "stop"
 
-      @_sendStateToSwitches(protocols, @_position is 'up').then( =>
-        @_setPosition('stopped')
-      )
+      state = if @config.inverted then @_position is 'down' else @_position is 'up'
+      @_sendStateToSwitches(protocols, state)
+        .then( =>
+          @_setPosition('stopped')
+        )
 
       return Promise.resolve()
 


### PR DESCRIPTION
Some people train their RF receiver of their shutter using the wrong button on a remote. Then the receiver is put into the wall and it's not easy to train it again. 
After adding the shutter device to pimatic, the button press for Up sends the shutter down and vice versa. 
This change adds a new option "inverted" which solves this problem, by just sending the opposite signal than normal if "inverted" is true. 
