### PR TITLE
option "inverted" for HomeduinoRFContactSensor

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -191,6 +191,10 @@ module.exports = {
         description: """Time after that the contact state is reseted."""
         type: "integer"
         default: 10000
+      inverted:
+        description: "Invert open/close state of contact device."
+        type: "boolean"
+        default: false
   }
   HomeduinoRFShutter: {
     title: "HomeduinoRFShutter config options"

--- a/homeduino.coffee
+++ b/homeduino.coffee
@@ -671,6 +671,7 @@ module.exports = (env) ->
               if event.values.contact? then event.values.contact
               else (not event.values.state)
             )
+            if @config.inverted then hasContact = !hasContact
             @_setContact(hasContact)
             if @config.autoReset is true
               clearTimeout(@_resetContactTimeout)


### PR DESCRIPTION
Added option "inverted" for HomeduinoRFContactSensor to get the correct state for devices like the VisorTech PX3952. Updated PR replaces #75